### PR TITLE
Remove Moment.js date parsing

### DIFF
--- a/data_object.coffee
+++ b/data_object.coffee
@@ -17,9 +17,6 @@ numberfy = (val) ->
   else
     val
 
-# Uses moment.js to parse and format the date into the correct format
-parseDate = (val) -> moment(val).format('MM/DD/YYYY') if val && val.length > 0
-
 
 # This class does all the heavy lifting.
 # It takes the and can format it into csv
@@ -57,7 +54,6 @@ class window.DataObject
             # Some YNAB columns need special formatting,
             #   the rest are just returned as they are.
             switch col
-              when 'Date' then tmp_row[col] = parseDate(cell)
               when 'Outflow'
                 number = numberfy(cell)
                 if lookup['Outflow'] == lookup['Inflow']


### PR DESCRIPTION
The date parsing code tries to guess the date format and often gets it wrong. YNAB parses multiple date formats and presents the date format options to the user in the web UI. I think it's better to just accept the raw date and let YNAB handle the parsing later.

This commit removes extra parsing for the date field.

Resolves #9.
