### PR TITLE
Replace commas with dots for European amounts to work

### DIFF
--- a/data_object.coffee
+++ b/data_object.coffee
@@ -11,7 +11,7 @@ numberfy = (val) ->
     # check for negative signs or parenthases.
     is_negative = if (val.match("-") || val.match(/\(.*\)/)) then -1 else 1
     # remove any commas
-    val = val.replace(/,/g, "")
+    val = val.replace(/,/g, ".")
     # return just the number and make it negative if needed.
     +(val.match(/\d+.?\d*/)[0]) * is_negative
   else


### PR DESCRIPTION
In European CSVs Numbers are formatted as »12,13«€ with »,« being the delimiter between Euros and Euro-Cents. Replacing the »,« with a ».« would allow the script to handle the CSVs.